### PR TITLE
Update new pages design and charts

### DIFF
--- a/kimi/index1.html
+++ b/kimi/index1.html
@@ -73,28 +73,148 @@
                 <div class="slide-content">
                     <h1 class="section-title">项目背景</h1>
                     <div class="background-content">
-                        <div class="background-section">
-                            <h3>市场环境</h3>
-                            <ul>
-                                <li>烟草行业数字化转型加速</li>
-                                <li>客户服务需求日益多元化</li>
-                                <li>竞争格局日趋激烈</li>
-                                <li>客户期望值不断提升</li>
-                            </ul>
-                        </div>
-                        <div class="background-section">
-                            <h3>客户需求洞察</h3>
-                            <ul>
-                                <li>个性化服务需求增长</li>
-                                <li>便捷高效的沟通渠道</li>
-                                <li>专业化的解决方案</li>
-                                <li>持续的价值创造</li>
-                            </ul>
+                        <div class="background-nav">
+                            <div class="background-nav-item" onclick="goToSlide(7)">
+                                <div class="nav-icon">👥</div>
+                                <h3>知民意</h3>
+                                <p>客户满意度调研分析</p>
+                            </div>
+                            <div class="background-nav-item" onclick="goToSlide(8)">
+                                <div class="nav-icon">📈</div>
+                                <h3>观市场</h3>
+                                <p>市场环境现状分析</p>
+                            </div>
+                            <div class="background-nav-item" onclick="goToSlide(9)">
+                                <div class="nav-icon">📋</div>
+                                <h3>学政策</h3>
+                                <p>行业政策解读</p>
+                            </div>
                         </div>
                     </div>
                     <div class="nav-section">
                         <button class="back-btn" onclick="goToSlide(1)">返回大纲</button>
                         <button class="nav-section-btn" onclick="goToSlide(3)">问题分析</button>
+                    </div>
+                </div>
+            </div>
+
+            <!-- 知民意页 -->
+            <div class="slide slide-survey">
+                <div class="leaf-bg-3"></div>
+                <div class="slide-content">
+                    <h1 class="section-title">知民意</h1>
+                    <div class="survey-content">
+                        <div class="chart-section">
+                            <h2 class="chart-title">批发服务细分指标情况</h2>
+                            <div class="horizontal-bar-chart" id="horizontalBarChart">
+                                <div class="chart-item">
+                                    <div class="chart-label">卷烟经营盈利水平</div>
+                                    <div class="chart-bar-container">
+                                        <div class="chart-bar" data-value="92.32" data-change="-1.79"></div>
+                                        <div class="chart-value-info">
+                                            <span class="chart-value">92.32%</span>
+                                            <span class="chart-change negative">-1.79%</span>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="chart-item">
+                                    <div class="chart-label">卷烟供应</div>
+                                    <div class="chart-bar-container">
+                                        <div class="chart-bar" data-value="92.53" data-change="1.22"></div>
+                                        <div class="chart-value-info">
+                                            <span class="chart-value">92.53%</span>
+                                            <span class="chart-change positive">+1.22%</span>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="chart-item">
+                                    <div class="chart-label">客户服务</div>
+                                    <div class="chart-bar-container">
+                                        <div class="chart-bar" data-value="96.67" data-change="-0.80"></div>
+                                        <div class="chart-value-info">
+                                            <span class="chart-value">96.67%</span>
+                                            <span class="chart-change negative">-0.80%</span>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="chart-item">
+                                    <div class="chart-label">卷烟销售平台</div>
+                                    <div class="chart-bar-container">
+                                        <div class="chart-bar" data-value="94.28" data-change="2.16"></div>
+                                        <div class="chart-value-info">
+                                            <span class="chart-value">94.28%</span>
+                                            <span class="chart-change positive">+2.16%</span>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="survey-summary">
+                            <h3>调研结果分析</h3>
+                            <p>通过对客户满意度的深入调研，我们发现客户服务满意度最高，达到96.67%，但相比去年有轻微下降。卷烟销售平台满意度提升显著，同比增长2.16%，显示出数字化服务的积极效果。</p>
+                        </div>
+                    </div>
+                    <div class="nav-section">
+                        <button class="back-btn" onclick="goToSlide(2)">返回项目背景</button>
+                        <button class="nav-section-btn" onclick="goToSlide(8)">观市场</button>
+                    </div>
+                </div>
+            </div>
+
+            <!-- 观市场页 -->
+            <div class="slide slide-market">
+                <div class="leaf-bg-3"></div>
+                <div class="slide-content">
+                    <h1 class="section-title">观市场</h1>
+                    <div class="market-content">
+                        <div class="market-section">
+                            <h3>市场环境分析</h3>
+                            <div class="market-item">
+                                <h4>行业发展趋势</h4>
+                                <p>烟草行业正经历深刻变革，数字化转型成为主要驱动力，客户需求日益多元化和个性化。</p>
+                            </div>
+                            <div class="market-item">
+                                <h4>竞争格局</h4>
+                                <p>市场竞争日趋激烈，服务质量和客户体验成为核心竞争要素。</p>
+                            </div>
+                            <div class="market-item">
+                                <h4>客户期望</h4>
+                                <p>客户对服务效率、专业程度和便捷性的期望值不断提升。</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="nav-section">
+                        <button class="back-btn" onclick="goToSlide(7)">知民意</button>
+                        <button class="nav-section-btn" onclick="goToSlide(9)">学政策</button>
+                    </div>
+                </div>
+            </div>
+
+            <!-- 学政策页 -->
+            <div class="slide slide-policy">
+                <div class="leaf-bg-3"></div>
+                <div class="slide-content">
+                    <h1 class="section-title">学政策</h1>
+                    <div class="policy-content">
+                        <div class="policy-section">
+                            <h3>行业政策导向</h3>
+                            <div class="policy-item">
+                                <h4>数字化转型政策</h4>
+                                <p>国家烟草专卖局大力推进行业数字化转型，要求各级单位加快信息化建设步伐。</p>
+                            </div>
+                            <div class="policy-item">
+                                <h4>服务质量提升</h4>
+                                <p>强调以客户为中心的服务理念，持续提升服务质量和客户满意度。</p>
+                            </div>
+                            <div class="policy-item">
+                                <h4>创新发展要求</h4>
+                                <p>鼓励各单位在服务模式、管理方式等方面积极创新，探索发展新路径。</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="nav-section">
+                        <button class="back-btn" onclick="goToSlide(8)">观市场</button>
+                        <button class="nav-section-btn" onclick="goToSlide(2)">返回项目背景</button>
                     </div>
                 </div>
             </div>

--- a/kimi/script1.js
+++ b/kimi/script1.js
@@ -55,6 +55,15 @@ function animateCurrentSlide() {
         case 2: // 背景页
             animateBackgroundPage();
             break;
+        case 7: // 知民意页
+            animateSurveyPage();
+            break;
+        case 8: // 观市场页
+            animateMarketPage();
+            break;
+        case 9: // 学政策页
+            animatePolicyPage();
+            break;
         case 3: // 分析页
             animateAnalysisPage();
             break;
@@ -96,16 +105,109 @@ function animateOutlinePage() {
 
 // 背景页动画
 function animateBackgroundPage() {
-    const sections = document.querySelectorAll('.background-section');
-    sections.forEach((section, index) => {
+    const navItems = document.querySelectorAll('.background-nav-item');
+    navItems.forEach((item, index) => {
         setTimeout(() => {
-            section.style.opacity = '0';
-            section.style.transform = 'translateX(-30px)';
-            section.style.transition = 'all 0.6s ease';
+            item.style.opacity = '0';
+            item.style.transform = 'translateY(30px)';
+            item.style.transition = 'all 0.6s ease';
             setTimeout(() => {
-                section.style.opacity = '1';
-                section.style.transform = 'translateX(0)';
+                item.style.opacity = '1';
+                item.style.transform = 'translateY(0)';
             }, 100);
+        }, index * 200);
+    });
+}
+
+// 知民意页动画
+function animateSurveyPage() {
+    // 动画图表标题
+    const chartTitle = document.querySelector('.chart-title');
+    if (chartTitle) {
+        chartTitle.style.opacity = '0';
+        chartTitle.style.transform = 'translateY(-20px)';
+        setTimeout(() => {
+            chartTitle.style.opacity = '1';
+            chartTitle.style.transform = 'translateY(0)';
+            chartTitle.style.transition = 'all 0.6s ease';
+        }, 200);
+    }
+
+    // 动画柱状图
+    animateBarChart();
+
+    // 动画调研总结
+    const surveySum = document.querySelector('.survey-summary');
+    if (surveySum) {
+        setTimeout(() => {
+            surveySum.style.opacity = '0';
+            surveySum.style.transform = 'translateY(30px)';
+            surveySum.style.transition = 'all 0.6s ease';
+            setTimeout(() => {
+                surveySum.style.opacity = '1';
+                surveySum.style.transform = 'translateY(0)';
+            }, 100);
+        }, 1500);
+    }
+}
+
+// 观市场页动画
+function animateMarketPage() {
+    const marketItems = document.querySelectorAll('.market-item');
+    marketItems.forEach((item, index) => {
+        setTimeout(() => {
+            item.style.opacity = '0';
+            item.style.transform = 'translateX(-30px)';
+            item.style.transition = 'all 0.6s ease';
+            setTimeout(() => {
+                item.style.opacity = '1';
+                item.style.transform = 'translateX(0)';
+            }, 100);
+        }, index * 200);
+    });
+}
+
+// 学政策页动画
+function animatePolicyPage() {
+    const policyItems = document.querySelectorAll('.policy-item');
+    policyItems.forEach((item, index) => {
+        setTimeout(() => {
+            item.style.opacity = '0';
+            item.style.transform = 'translateX(30px)';
+            item.style.transition = 'all 0.6s ease';
+            setTimeout(() => {
+                item.style.opacity = '1';
+                item.style.transform = 'translateX(0)';
+            }, 100);
+        }, index * 200);
+    });
+}
+
+// 柱状图动画
+function animateBarChart() {
+    const chartItems = document.querySelectorAll('.chart-item');
+    chartItems.forEach((item, index) => {
+        const bar = item.querySelector('.chart-bar');
+        const value = parseFloat(bar.getAttribute('data-value'));
+        
+        // 初始状态
+        item.style.opacity = '0';
+        item.style.transform = 'translateY(20px)';
+        bar.style.width = '0%';
+        
+        setTimeout(() => {
+            // 显示图表项
+            item.style.opacity = '1';
+            item.style.transform = 'translateY(0)';
+            item.style.transition = 'all 0.5s ease';
+            
+            // 延迟后开始柱状图动画
+            setTimeout(() => {
+                const maxValue = 100;
+                const widthPercentage = (value / maxValue) * 80; // 最大宽度为80%
+                bar.style.width = widthPercentage + '%';
+                bar.style.transition = 'width 2s ease-out';
+            }, 300);
         }, index * 300);
     });
 }

--- a/kimi/style.css
+++ b/kimi/style.css
@@ -262,7 +262,7 @@ body {
 }
 
 /* 背景页样式 */
-.slide-background {
+.slide-background, .slide-survey, .slide-market, .slide-policy {
     background: linear-gradient(135deg, #da9408 0%, #f0f1a3 100%);
     color: #333;
 }
@@ -306,6 +306,276 @@ body {
     position: absolute;
     left: 0;
     color: #da9408;
+}
+
+/* 背景导航样式 */
+.background-nav {
+    display: flex;
+    justify-content: center;
+    gap: 40px;
+    flex-wrap: wrap;
+}
+
+.background-nav-item {
+    background: rgba(255, 255, 255, 0.1);
+    backdrop-filter: blur(10px);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 20px;
+    padding: 30px;
+    text-align: center;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    min-width: 200px;
+    box-shadow: 0 8px 32px rgba(31, 38, 135, 0.15);
+}
+
+.background-nav-item:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 15px 40px rgba(31, 38, 135, 0.25);
+    background: rgba(255, 255, 255, 0.15);
+}
+
+.background-nav-item .nav-icon {
+    font-size: 2.5em;
+    margin-bottom: 15px;
+}
+
+.background-nav-item h3 {
+    color: #2c3e50;
+    margin: 15px 0 10px 0;
+    font-size: 1.4em;
+    font-weight: 600;
+}
+
+.background-nav-item p {
+    color: #5a6c7d;
+    font-size: 0.9em;
+    line-height: 1.5;
+}
+
+/* 知民意页面样式 */
+.survey-content {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 20px;
+}
+
+.chart-section {
+    background: rgba(255, 255, 255, 0.05);
+    backdrop-filter: blur(10px);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 20px;
+    padding: 40px;
+    margin-bottom: 30px;
+    box-shadow: 0 8px 32px rgba(31, 38, 135, 0.1);
+}
+
+.chart-title {
+    text-align: center;
+    color: #2c3e50;
+    font-size: 1.8em;
+    margin-bottom: 40px;
+    font-weight: 600;
+}
+
+.horizontal-bar-chart {
+    display: flex;
+    flex-direction: column;
+    gap: 25px;
+}
+
+.chart-item {
+    display: flex;
+    align-items: center;
+    gap: 20px;
+    padding: 15px;
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: 15px;
+    transition: all 0.3s ease;
+}
+
+.chart-item:hover {
+    background: rgba(255, 255, 255, 0.1);
+    transform: translateY(-2px);
+}
+
+.chart-label {
+    min-width: 150px;
+    font-weight: 600;
+    color: #2c3e50;
+    text-align: right;
+    padding-right: 20px;
+}
+
+.chart-bar-container {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    gap: 15px;
+}
+
+.chart-bar {
+    height: 30px;
+    background: linear-gradient(90deg, #4CAF50, #8BC34A);
+    border-radius: 15px;
+    position: relative;
+    overflow: hidden;
+    min-width: 0;
+    width: 0%;
+}
+
+.chart-bar[data-change*="-"] {
+    background: linear-gradient(90deg, #FF6B6B, #FF8E8E);
+}
+
+.chart-value-info {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-width: 120px;
+}
+
+.chart-value {
+    font-weight: 700;
+    color: #2c3e50;
+    font-size: 1.1em;
+}
+
+.chart-change {
+    font-size: 0.9em;
+    font-weight: 600;
+    padding: 2px 8px;
+    border-radius: 10px;
+    background: rgba(255, 255, 255, 0.2);
+}
+
+.chart-change.positive {
+    color: #27AE60;
+}
+
+.chart-change.negative {
+    color: #E74C3C;
+}
+
+@keyframes growBar {
+    from {
+        width: 0%;
+    }
+    to {
+        width: 100%;
+    }
+}
+
+.survey-summary {
+    background: rgba(255, 255, 255, 0.05);
+    backdrop-filter: blur(10px);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 20px;
+    padding: 30px;
+    box-shadow: 0 8px 32px rgba(31, 38, 135, 0.1);
+}
+
+.survey-summary h3 {
+    color: #2c3e50;
+    font-size: 1.5em;
+    margin-bottom: 20px;
+    font-weight: 600;
+}
+
+.survey-summary p {
+    color: #5a6c7d;
+    line-height: 1.8;
+    font-size: 1.1em;
+}
+
+/* 观市场页面样式 */
+.market-content {
+    max-width: 1000px;
+    margin: 0 auto;
+    padding: 20px;
+}
+
+.market-section {
+    background: rgba(255, 255, 255, 0.05);
+    backdrop-filter: blur(10px);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 20px;
+    padding: 40px;
+    box-shadow: 0 8px 32px rgba(31, 38, 135, 0.1);
+}
+
+.market-section h3 {
+    color: #2c3e50;
+    font-size: 1.8em;
+    margin-bottom: 30px;
+    text-align: center;
+    font-weight: 600;
+}
+
+.market-item {
+    margin-bottom: 25px;
+    padding: 20px;
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: 15px;
+    border-left: 4px solid #da9408;
+}
+
+.market-item h4 {
+    color: #2c3e50;
+    font-size: 1.3em;
+    margin-bottom: 15px;
+    font-weight: 600;
+}
+
+.market-item p {
+    color: #5a6c7d;
+    line-height: 1.8;
+    font-size: 1.05em;
+}
+
+/* 学政策页面样式 */
+.policy-content {
+    max-width: 1000px;
+    margin: 0 auto;
+    padding: 20px;
+}
+
+.policy-section {
+    background: rgba(255, 255, 255, 0.05);
+    backdrop-filter: blur(10px);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 20px;
+    padding: 40px;
+    box-shadow: 0 8px 32px rgba(31, 38, 135, 0.1);
+}
+
+.policy-section h3 {
+    color: #2c3e50;
+    font-size: 1.8em;
+    margin-bottom: 30px;
+    text-align: center;
+    font-weight: 600;
+}
+
+.policy-item {
+    margin-bottom: 25px;
+    padding: 20px;
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: 15px;
+    border-left: 4px solid #da9408;
+}
+
+.policy-item h4 {
+    color: #2c3e50;
+    font-size: 1.3em;
+    margin-bottom: 15px;
+    font-weight: 600;
+}
+
+.policy-item p {
+    color: #5a6c7d;
+    line-height: 1.8;
+    font-size: 1.05em;
 }
 
 /* 分析页样式 */


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add "知民意", "观市场", "学政策" pages with unified backgrounds, redesigned content boxes, and a dynamic horizontal bar chart to improve visual consistency and data presentation.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous "知民意" page used a stark white content box and a static image for data presentation, which was visually jarring and lacked interactivity. This PR addresses these issues by implementing a softer, semi-transparent content box and a dynamic bar chart that visually represents satisfaction levels and year-over-year changes for key metrics, enhancing user engagement and data clarity.

---
<a href="https://cursor.com/background-agent?bcId=bc-0390b91c-457e-4616-8d1b-bd05679ffe58">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0390b91c-457e-4616-8d1b-bd05679ffe58">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

